### PR TITLE
New :with arg

### DIFF
--- a/test/leiningen/test/multi.clj
+++ b/test/leiningen/test/multi.clj
@@ -67,3 +67,8 @@
   (is (.exists (file "multi-test-new-project")))
   (delete-file-recursively (file "multi-test-new-project") true))
 
+#_(deftest test-with-dep
+   (let [test-project (add-clojure-deps test-project "1.1.0" "1.2.0")
+	     result (multi test-project "classpath" :with "1.2.0")]
+     (is (= result []))))
+


### PR DESCRIPTION
I added the option to specific a dependency set for any lein command.  For example:

lein multi repl :with 1.3

Would run the repl command for my dep-set keyed by "1.3"
The test suite is failing in my pull of the repo, but I stubbed in a test for the added functionality.
