### PR TITLE
Additional fixes for :with functionality

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,9 +1,9 @@
-(defproject lein-multi "1.0.0"
+(defproject lein-multi "1.0.1"
   :description "A Leiningen plugin for running tasks against multiple dependency sets."
-  :url "http://github.com/maravillas/lein-multi"
+  :url "http://github.com/ohpauleez/lein-multi"
   :license {:name "MIT License"
             :url "http://www.opensource.org/licenses/mit-license.php"}
-  :dev-dependencies [[org.clojure/clojure "1.2.0"]
-		     [org.clojure/clojure-contrib "1.2.0"]
-		     [lein-clojars "0.5.0-SNAPSHOT"]
+  :dev-dependencies [[org.clojure/clojure "1.2.1"]
+		     [org.clojure/clojure-contrib "1.2.1"]
 		     [swank-clojure "1.2.1"]])
+

--- a/project.clj
+++ b/project.clj
@@ -4,6 +4,6 @@
   :license {:name "MIT License"
             :url "http://www.opensource.org/licenses/mit-license.php"}
   :dev-dependencies [[org.clojure/clojure "1.2.1"]
-		     [org.clojure/clojure-contrib "1.2.1"]
+		     [org.clojure/clojure-contrib "1.2.0"]
 		     [swank-clojure "1.2.1"]])
 

--- a/src/leiningen/multi.clj
+++ b/src/leiningen/multi.clj
@@ -37,9 +37,13 @@
            (:multi-deps project))))
   ([task-fn project delimiter-fn depkey] ;; force task for dep set via depkey
       {:pre [(not-empty depkey)]}
-      (let [depvec ((:multi-deps project) depkey)]
-        (delimiter-fn depkey depvec)
-        (task-fn (project-for-set project depkey depvec)))))
+      (if-let [deps (:multi-deps project)]
+        (if-let [depvec (deps depkey)]
+          (do
+            (delimiter-fn depkey depvec)
+            (task-fn (project-for-set project depkey depvec)))
+          (println "No version:" depkey "found in multi-deps"))
+        (println "No multi-deps specified in project.clj"))))
 
 (defn- print-base-message
   [task project]


### PR DESCRIPTION
The following two commits make the :with handler more roust to errors and keys that aren't in the multi-dep map.  Additionally, the project.clj was updated to use Clojure 1.2.1 instead of Clojure1.2.0
